### PR TITLE
Fix Culture of Tests

### DIFF
--- a/src/CslaGeneratorSerialization.Analysis.Tests/Descriptors/BusinessObjectDoesNotHaveSerializationAttributeDescriptorTests.cs
+++ b/src/CslaGeneratorSerialization.Analysis.Tests/Descriptors/BusinessObjectDoesNotHaveSerializationAttributeDescriptorTests.cs
@@ -16,8 +16,8 @@ internal static class BusinessObjectDoesNotHaveSerializationAttributeDescriptorT
 		using (Assert.EnterMultipleScope())
 		{
 			Assert.That(descriptor.Id, Is.EqualTo(BusinessObjectDoesNotHaveSerializationAttributeDescriptor.Id));
-			Assert.That(descriptor.Title.ToString(CultureInfo.CurrentCulture), Is.EqualTo(BusinessObjectDoesNotHaveSerializationAttributeDescriptor.Title));
-			Assert.That(descriptor.MessageFormat.ToString(CultureInfo.CurrentCulture), Is.EqualTo(BusinessObjectDoesNotHaveSerializationAttributeDescriptor.Message));
+			Assert.That(descriptor.Title.ToString(CultureInfo.InvariantCulture), Is.EqualTo(BusinessObjectDoesNotHaveSerializationAttributeDescriptor.Title));
+			Assert.That(descriptor.MessageFormat.ToString(CultureInfo.InvariantCulture), Is.EqualTo(BusinessObjectDoesNotHaveSerializationAttributeDescriptor.Message));
 			Assert.That(descriptor.DefaultSeverity, Is.EqualTo(DiagnosticSeverity.Error));
 			Assert.That(descriptor.Category, Is.EqualTo(DiagnosticConstants.Usage));
 			Assert.That(descriptor.HelpLinkUri, Is.EqualTo(HelpUrlBuilder.Build(

--- a/src/CslaGeneratorSerialization.Analysis.Tests/Diagnostics/BusinessObjectDoesNotHaveSerializationAttributeDiagnosticTests.cs
+++ b/src/CslaGeneratorSerialization.Analysis.Tests/Diagnostics/BusinessObjectDoesNotHaveSerializationAttributeDiagnosticTests.cs
@@ -26,7 +26,7 @@ internal static class BusinessObjectDoesNotHaveSerializationAttributeDiagnosticT
 		using (Assert.EnterMultipleScope())
 		{
 			Assert.That(descriptor.GetMessage(CultureInfo.InvariantCulture), Is.EqualTo("The type X is not marked with GeneratorSerializableAttribute"));
-			Assert.That(descriptor.Descriptor.Title.ToString(CultureInfo.CurrentCulture), Is.EqualTo(BusinessObjectDoesNotHaveSerializationAttributeDescriptor.Title));
+			Assert.That(descriptor.Descriptor.Title.ToString(CultureInfo.InvariantCulture), Is.EqualTo(BusinessObjectDoesNotHaveSerializationAttributeDescriptor.Title));
 			Assert.That(descriptor.Id, Is.EqualTo(BusinessObjectDoesNotHaveSerializationAttributeDescriptor.Id));
 			Assert.That(descriptor.Severity, Is.EqualTo(DiagnosticSeverity.Error));
 		}

--- a/src/CslaGeneratorSerialization.IntegrationTests/ValueTypes/BigIntegerTests.cs
+++ b/src/CslaGeneratorSerialization.IntegrationTests/ValueTypes/BigIntegerTests.cs
@@ -48,7 +48,7 @@ internal static class BigIntegerTests
 		var portal = provider.GetRequiredService<IDataPortal<BigIntegerData>>();
 		var data = await portal.CreateAsync();
 
-		data.Contents = BigInteger.Parse("750389174809371089431", CultureInfo.CurrentCulture);
+		data.Contents = BigInteger.Parse("750389174809371089431", CultureInfo.InvariantCulture);
 
 		using var stream = new MemoryStream();
 		formatter.Serialize(stream, data);
@@ -66,7 +66,7 @@ internal static class BigIntegerTests
 		var portal = provider.GetRequiredService<IDataPortal<BigIntegerNullableData>>();
 		var data = await portal.CreateAsync();
 
-		data.Contents = BigInteger.Parse("750389174809371089431", CultureInfo.CurrentCulture);
+		data.Contents = BigInteger.Parse("750389174809371089431", CultureInfo.InvariantCulture);
 		data.Contents = null;
 
 		using var stream = new MemoryStream();

--- a/src/CslaGeneratorSerialization.IntegrationTests/ValueTypes/HalfTests.cs
+++ b/src/CslaGeneratorSerialization.IntegrationTests/ValueTypes/HalfTests.cs
@@ -47,7 +47,7 @@ internal static class HalfTests
 		var portal = provider.GetRequiredService<IDataPortal<HalfData>>();
 		var data = await portal.CreateAsync();
 
-		data.Contents = Half.Parse("3.14", CultureInfo.CurrentCulture);
+		data.Contents = Half.Parse("3.14", CultureInfo.InvariantCulture);
 
 		using var stream = new MemoryStream();
 		formatter.Serialize(stream, data);
@@ -65,7 +65,7 @@ internal static class HalfTests
 		var portal = provider.GetRequiredService<IDataPortal<HalfNullableData>>();
 		var data = await portal.CreateAsync();
 
-		data.Contents = Half.Parse("3.14", CultureInfo.CurrentCulture);
+		data.Contents = Half.Parse("3.14", CultureInfo.InvariantCulture);
 		data.Contents = null;
 
 		using var stream = new MemoryStream();

--- a/src/CslaGeneratorSerialization.Performance/Program.cs
+++ b/src/CslaGeneratorSerialization.Performance/Program.cs
@@ -5,7 +5,7 @@ value.ToByteArray();
 
 /*
 new Int128()
-var value = UInt128.Parse("-3333", CultureInfo.CurrentCulture);// new UInt128(222, 333);
+var value = UInt128.Parse("-3333", CultureInfo.InvariantCulture);// new UInt128(222, 333);
 Console.WriteLine(value);
 
 value.

--- a/src/CslaGeneratorSerialization.Tests/Extensions/BinaryReaderExtensionsTests.cs
+++ b/src/CslaGeneratorSerialization.Tests/Extensions/BinaryReaderExtensionsTests.cs
@@ -24,7 +24,7 @@ internal static class BinaryReaderExtensionsTests
 	[Test]
 	public static async Task ReadBigIntegerAsync()
 	{
-		var value = BigInteger.Parse("473107483917948931749814", CultureInfo.CurrentCulture);
+		var value = BigInteger.Parse("473107483917948931749814", CultureInfo.InvariantCulture);
 
 		var stream = new MemoryStream();
 		using var writer = new BinaryWriter(stream);

--- a/src/CslaGeneratorSerialization.Tests/Extensions/BinaryWriterExtensionsTests.cs
+++ b/src/CslaGeneratorSerialization.Tests/Extensions/BinaryWriterExtensionsTests.cs
@@ -10,7 +10,7 @@ internal static class BinaryWriterExtensionsTests
 	[Test]
 	public static async Task WriteBigIntegerAsync()
 	{
-		var number = BigInteger.Parse("473107483917948931749814", CultureInfo.CurrentCulture);
+		var number = BigInteger.Parse("473107483917948931749814", CultureInfo.InvariantCulture);
 
 		var stream = new MemoryStream();
 		using var writer = new BinaryWriter(stream);


### PR DESCRIPTION
fixes #52

### Summary

Replace `CurrentCulture` with `InvariantCulture` in Tests.

### Remarks

Proposing **Solution 1** from #52.

Parsing floating-point numeric types, that expect `'.'` as _decimal point_, fails on systems with an incompatible `CultureInfo`. Changing from `CultureInfo.CurrentCulture` to `CultureInfo.InvariantCulture` aligns the behavior on all systems.
